### PR TITLE
Add docker-compose setup with basic services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # PIIXtractor
 PIIXtractor
+
+## Running with Docker Compose
+
+Build and start the services using:
+
+```bash
+docker-compose up --build
+```
+
+This starts two containers:
+
+- **extractor**: Flask application listening on port `8000`. The directory `./extractor` is mounted into the container at `/app`.
+- **web**: Flask application listening on port `5000` and depends on the extractor service. The directory `./web` is mounted into the container at `/app`.
+
+The services will be available at `http://localhost:8000` for the extractor and `http://localhost:5000` for the web interface.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  extractor:
+    build: ./extractor
+    volumes:
+      - ./extractor:/app
+    ports:
+      - "8000:8000"
+  web:
+    build: ./web
+    volumes:
+      - ./web:/app
+    ports:
+      - "5000:5000"
+    depends_on:
+      - extractor

--- a/extractor/Dockerfile
+++ b/extractor/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY app.py .
+RUN pip install flask
+CMD ["python", "app.py"]

--- a/extractor/app.py
+++ b/extractor/app.py
@@ -1,0 +1,9 @@
+from flask import Flask
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return "PII Extraction Service"
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY app.py .
+RUN pip install flask
+CMD ["python", "app.py"]

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,9 @@
+from flask import Flask
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return "PIIXtractor Web Interface"
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- set up `docker-compose.yml` for `extractor` and `web` services
- add Dockerfiles and simple Flask apps for each service
- document how to run the stack with Docker Compose

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ac881472483308a75f8995ee155c5