### PR TITLE
Add export utilities and driver script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ OpenAI para melhorar a detecção de dados.
 
 1. Coloque o arquivo ZIP contendo os documentos no mesmo diretório.
 2. Defina a variável de ambiente `OPENAI_API_KEY` com sua chave.
-3. Execute o script principal:
+3. Execute o script `extractor_drive.py` para processar o ZIP e salvar os dados:
 
 ```bash
-python pii_extractor.py
+python extractor_drive.py
 ```
 
 Durante o processamento será exibida uma barra de progresso indicando o avanço.

--- a/extractor/exporters.py
+++ b/extractor/exporters.py
@@ -1,0 +1,72 @@
+import os
+import csv
+import json
+import sqlite3
+from typing import Dict, Any
+
+
+def export_csv(resultados: Dict[str, Any], caminho: str = "data/resultados.csv") -> None:
+    """Exporta os resultados para um arquivo CSV."""
+    os.makedirs(os.path.dirname(caminho), exist_ok=True)
+    with open(caminho, "w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["arquivo", "origem", "tipo", "valor"])
+        for arquivo, dados in resultados.items():
+            for origem in ["regex", "gpt"]:
+                info = dados.get(origem)
+                if isinstance(info, dict):
+                    for tipo, valores in info.items():
+                        if isinstance(valores, list):
+                            for valor in valores:
+                                writer.writerow([arquivo, origem, tipo, valor])
+                        else:
+                            writer.writerow([arquivo, origem, tipo, valores])
+                else:
+                    writer.writerow([arquivo, origem, "conteudo", info])
+
+
+def export_json(resultados: Dict[str, Any], caminho: str = "data/resultados.json") -> None:
+    """Exporta os resultados para um arquivo JSON."""
+    os.makedirs(os.path.dirname(caminho), exist_ok=True)
+    with open(caminho, "w", encoding="utf-8") as f:
+        json.dump(resultados, f, indent=2, ensure_ascii=False)
+
+
+def export_sqlite(resultados: Dict[str, Any], db_path: str = "data/resultados.db") -> None:
+    """Exporta os resultados para um banco de dados SQLite."""
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dados (
+            arquivo TEXT,
+            origem TEXT,
+            tipo TEXT,
+            valor TEXT
+        )
+        """
+    )
+    for arquivo, dados in resultados.items():
+        for origem in ["regex", "gpt"]:
+            info = dados.get(origem)
+            if isinstance(info, dict):
+                for tipo, valores in info.items():
+                    if isinstance(valores, list):
+                        for valor in valores:
+                            cursor.execute(
+                                "INSERT INTO dados VALUES (?, ?, ?, ?)",
+                                (arquivo, origem, tipo, valor),
+                            )
+                    else:
+                        cursor.execute(
+                            "INSERT INTO dados VALUES (?, ?, ?, ?)",
+                            (arquivo, origem, tipo, valores),
+                        )
+            else:
+                cursor.execute(
+                    "INSERT INTO dados VALUES (?, ?, ?, ?)",
+                    (arquivo, origem, "conteudo", info),
+                )
+    conn.commit()
+    conn.close()

--- a/extractor_drive.py
+++ b/extractor_drive.py
@@ -1,0 +1,25 @@
+import os
+import logging
+
+from pii_extractor import extrair_e_processar_zip
+from extractor.exporters import export_csv, export_json, export_sqlite
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)s | %(message)s",
+)
+
+
+def main(zip_file: str) -> None:
+    """Processa o ZIP informado e exporta os resultados."""
+    resultados = extrair_e_processar_zip(zip_file)
+    export_csv(resultados)
+    export_json(resultados)
+    export_sqlite(resultados)
+    logging.info("Exportação concluída: CSV, JSON e SQLite")
+
+
+if __name__ == "__main__":
+    zip_file = os.getenv("ZIP_INPUT", "columbiati.zip")
+    main(zip_file)


### PR DESCRIPTION
## Summary
- add `exporters` module under `extractor/` for CSV, JSON and SQLite output
- add `extractor_drive.py` that processes the ZIP and exports results
- update README to document using the new driver script

## Testing
- `python -m py_compile extractor/exporters.py extractor_drive.py pii_extractor.py`


------
https://chatgpt.com/codex/tasks/task_b_684ac94e9e188330809651c7ef2f8ac5