### PR TITLE
Add normalization module and integrate into drive script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ OpenAI para melhorar a detecção de dados.
 3. Execute o script principal:
 
 ```bash
-python pii_extractor.py
+python extractor_drive.py
 ```
 
 Durante o processamento será exibida uma barra de progresso indicando o avanço.

--- a/extractor_drive.py
+++ b/extractor_drive.py
@@ -1,0 +1,29 @@
+"""Entry point for running PII extraction and exporting results."""
+
+import logging
+import os
+
+from pii_extractor import (
+    extrair_e_processar_zip,
+    exportar_resultados_csv,
+    exportar_resultados_json,
+    exportar_resultados_sqlite,
+)
+from normalization import normalize_results
+
+
+def main() -> None:
+    zip_file = os.getenv("ZIP_INPUT", "columbiati.zip")
+    resultados = extrair_e_processar_zip(zip_file)
+
+    # Normalize extracted values before exporting
+    resultados = normalize_results(resultados)
+
+    exportar_resultados_csv(resultados, caminho_csv="resultados.csv")
+    exportar_resultados_json(resultados, caminho_json="resultados.json")
+    exportar_resultados_sqlite(resultados, db_path="resultados.db")
+    logging.info("Exportação concluída: CSV, JSON e SQLite.")
+
+
+if __name__ == "__main__":
+    main()

--- a/normalization.py
+++ b/normalization.py
@@ -1,0 +1,28 @@
+"""Utilities for normalizing extracted PII results."""
+
+from typing import Dict, Any
+
+
+def normalize_results(resultados: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a new dict with duplicates removed and values sorted.
+
+    Iterates over the nested results structure produced by ``processar_diretorio``
+    and ensures each list of extracted values is converted to a ``set`` to remove
+    duplicates and then sorted.
+    """
+    normalizados: Dict[str, Any] = {}
+    for arquivo, dados in resultados.items():
+        arquivo_dict: Dict[str, Any] = {}
+        for origem, info in dados.items():
+            if isinstance(info, dict):
+                origem_dict: Dict[str, Any] = {}
+                for tipo, valores in info.items():
+                    if isinstance(valores, list):
+                        origem_dict[tipo] = sorted(set(valores))
+                    else:
+                        origem_dict[tipo] = valores
+                arquivo_dict[origem] = origem_dict
+            else:
+                arquivo_dict[origem] = info
+        normalizados[arquivo] = arquivo_dict
+    return normalizados


### PR DESCRIPTION
## Summary
- add normalization step to deduplicate and sort extracted values
- provide a new `extractor_drive.py` that normalizes results before export
- update README usage example to call the new drive script

## Testing
- `python -m py_compile normalization.py`
- `python -m py_compile extractor_drive.py`
- `python -m py_compile pii_extractor.py`


------
https://chatgpt.com/codex/tasks/task_b_684ac94d280083309ee2d329fc738cb9