### PR TITLE
Refactor exporter usage and add tests

### DIFF
--- a/extractor_project/extractor_drive.py
+++ b/extractor_project/extractor_drive.py
@@ -4,12 +4,8 @@ import zipfile
 import logging
 import shutil
 
-from pii_extractor import (
-    processar_diretorio,
-    exportar_resultados_csv,
-    exportar_resultados_json,
-    exportar_resultados_sqlite,
-)
+from pii_extractor import processar_diretorio
+from extractor.exporters import export_csv, export_json, export_sqlite
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 TMP_DIR = os.path.join(BASE_DIR, 'tmp')
@@ -36,9 +32,9 @@ def run_pipeline(zip_file: str) -> None:
     extract_zip(zip_file)
     results = processar_diretorio(TMP_DIR)
     os.makedirs(DATA_DIR, exist_ok=True)
-    exportar_resultados_csv(results, os.path.join(DATA_DIR, 'resultados.csv'))
-    exportar_resultados_json(results, os.path.join(DATA_DIR, 'resultados.json'))
-    exportar_resultados_sqlite(results, os.path.join(DATA_DIR, 'resultados.db'))
+    export_csv(results, os.path.join(DATA_DIR, 'resultados.csv'))
+    export_json(results, os.path.join(DATA_DIR, 'resultados.json'))
+    export_sqlite(results, os.path.join(DATA_DIR, 'resultados.db'))
     clean_tmp()
 
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,0 +1,47 @@
+import csv
+import json
+import sqlite3
+from extractor.exporters import export_csv, export_json, export_sqlite
+
+SAMPLE_RESULTS = {
+    "file1.txt": {
+        "regex": {"email": ["a@test.com"], "cpf": ["123"]},
+        "gpt": "Detected PII",
+    }
+}
+
+
+def test_export_csv(tmp_path):
+    out = tmp_path / "out.csv"
+    export_csv(SAMPLE_RESULTS, caminho=str(out))
+    with open(out, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    assert rows[0] == ["arquivo", "origem", "tipo", "valor"]
+    assert sorted(rows[1:]) == sorted([
+        ["file1.txt", "regex", "email", "a@test.com"],
+        ["file1.txt", "regex", "cpf", "123"],
+        ["file1.txt", "gpt", "conteudo", "Detected PII"],
+    ])
+
+
+def test_export_json(tmp_path):
+    out = tmp_path / "out.json"
+    export_json(SAMPLE_RESULTS, caminho=str(out))
+    with open(out, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data == SAMPLE_RESULTS
+
+
+def test_export_sqlite(tmp_path):
+    db = tmp_path / "out.db"
+    export_sqlite(SAMPLE_RESULTS, db_path=str(db))
+    conn = sqlite3.connect(db)
+    cursor = conn.cursor()
+    cursor.execute("SELECT arquivo, origem, tipo, valor FROM dados")
+    rows = sorted(cursor.fetchall())
+    conn.close()
+    assert rows == sorted([
+        ("file1.txt", "regex", "email", "a@test.com"),
+        ("file1.txt", "regex", "cpf", "123"),
+        ("file1.txt", "gpt", "conteudo", "Detected PII"),
+    ])


### PR DESCRIPTION
## Summary
- use exporter functions from `extractor.exporters`
- update CLI scripts to rely on the exporter module
- add unit tests verifying CSV, JSON and SQLite export

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ad69f100083308c920faafc75cd7b